### PR TITLE
refactor(package.json): Move plugins to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "eslint-config-inturn",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "an eslint config used by the development team at inturn",
   "main": "index.js",
   "scripts": {},
   "author": "Inturn",
   "license": "MIT",
-  "peerDependencies": {
-    "babel-eslint": "^10.0.1",
-    "eslint": "^5.12.1",
+  "dependencies": {
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.1.0",
     "eslint-import-resolver-webpack": "^0.11.0",
@@ -19,5 +17,9 @@
     "eslint-plugin-jsx-a11y": "^6.2.0",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4"
+  },
+  "peerDependencies": {
+    "babel-eslint": "^10.0.1",
+    "eslint": "^5.12.1"
   }
 }

--- a/tags
+++ b/tags
@@ -1,0 +1,7 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+module.exports.extends	index.js	/^  extends: [$/;"	p


### PR DESCRIPTION
Move plugin deps to dependencies, so you don't have to install them locally